### PR TITLE
Add simple Codex setup script

### DIFF
--- a/codex/setup.sh
+++ b/codex/setup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+# Install runtime dependencies
+if [ -f "requirements.txt" ]; then
+    python -m pip install -r requirements.txt
+fi
+
+# Install pytest so tests can be executed
+python -m pip install pytest
+


### PR DESCRIPTION
## Summary
- provide `codex/setup.sh` to install dependencies and pytest

## Testing
- `./codex/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b81b60c483299415e959918f0a45